### PR TITLE
lazy loading and width+height for <img>

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -240,7 +240,7 @@
 
         <div class="container mx-auto md:container md:mx-auto grid grid-cols-12 px-3 xl:px-0">
             <div id="jesper" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/jesper-zedlitz.webp" alt="Jesper Zedlitz, Staatskanzlei Kiel" loading="lazy" width="600" height="600">
+                <img class="h-44 lg:h-52 xl:h-48 w-auto rounded-full" src="./static/jesper-zedlitz.webp" alt="Jesper Zedlitz, Staatskanzlei Kiel" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Open Data Schleswig-Holstein Aktueller Stand und Ausblick</h3>
@@ -250,7 +250,7 @@
             </div>
 
             <div id="philip" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/philip-steffan.webp" alt="Philip Steffan, Jugend hackt" loading="lazy" width="600" height="600">
+                <img class="h-44 lg:h-52 xl:h-48 w-auto rounded-full" src="./static/philip-steffan.webp" alt="Philip Steffan, Jugend hackt" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Das Programm Jugend hackt - Mit Code die Welt verbessern</h3>
@@ -262,7 +262,7 @@
             </div>
 
             <div id="stk" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/stefan-kaufmann.webp" alt="Stefan Kaufmann, Wikimedia Deutschland" loading="lazy" width="600" height="600">
+                <img class="h-44 lg:h-52 xl:h-48 w-auto rounded-full" src="./static/stefan-kaufmann.webp" alt="Stefan Kaufmann, Wikimedia Deutschland" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Open Data als Indikator für gelungene Verwaltungsdigitalisierung</h3>
@@ -273,7 +273,7 @@
 
 
             <div id="malte" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/malte-zinke.webp" alt="Malte Zinke, Smarte Grenzregion" loading="lazy" width="512" height="512">
+                <img class="h-44 lg:h-52 xl:h-48 w-auto rounded-full" src="./static/malte-zinke.webp" alt="Malte Zinke, Smarte Grenzregion" loading="lazy" width="512" height="512">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-3 lg:mb-16">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Praktische Anwendungsfälle von Open Data in der Smarten Grenzregion</h3>
@@ -283,7 +283,7 @@
             </div>
 
             <div id="ulf" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/ulf-andree-strohbach.webp" alt="Ulf Andree Strohbach, C20 Kiel" loading="lazy" width="600" height="605">
+                <img class="h-44 lg:h-52 xl:h-48 w-auto rounded-full" src="./static/ulf-andree-strohbach.webp" alt="Ulf Andree Strohbach, C20 Kiel" loading="lazy" width="600" height="605">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-3 lg:mb-16">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Cyberangriffe mit ChatGPT und generativer KI</h3>

--- a/src/index.html
+++ b/src/index.html
@@ -366,7 +366,7 @@
         </div>
 
         <div class="container mx-auto px-3 xl:px-0">
-            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Ein Event vom OK Lab Flensburg
+            <p class="text-lg lg:text-2xl leading-7 pb-5 lg:pb-8">Ein Event vom OK Lab Flensburg
                 <a href="https://oklabflensburg.de/">
                     <img class="inline" src="./static/oklabflensburg-logo.svg" alt="OK Lab Flensburg" loading="lazy" width="130" height="150">
                 </a>

--- a/src/index.html
+++ b/src/index.html
@@ -319,12 +319,12 @@
             <div class="grid grid-cols-12 gap-4 lg:gap-8 pb-4 lg:pb-8 px-3 xl:px-0">
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://hs-flensburg.de" class="flex items-center justify-center h-14 md:h-32" title="Hochschule Flensburg" target="_blank">
-                        <img src="./static/hochschule-flensburg.svg" class="w-4/5" alt="Hochschule Flensburg" loading="lazy" width="223" height="150">
+                        <img src="./static/hochschule-flensburg.svg" class="w-3/5" alt="Hochschule Flensburg" loading="lazy" width="223" height="150">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://okfn.de" class="flex items-center justify-center h-14 md:h-32" title="Open Knowledge Foundation Deutschland" target="_blank">
-                        <img src="./static/okfde.svg" class="w-4/5" alt="Open Knowledge Foundation Deutschland" loading="lazy" width="300" height="136">
+                        <img src="./static/okfde.svg" class="w-3/5" alt="Open Knowledge Foundation Deutschland" loading="lazy" width="300" height="136">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
@@ -334,32 +334,32 @@
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.sdu.de" class="flex items-center justify-center h-14 md:h-32" title="Sydslesvigs danske Ungdomsforeninger" target="_blank">
-                        <img src="./static/sdu.svg" class="w-4/5" alt="Sydslesvigs danske Ungdomsforeninger" loading="lazy" width="300" height="120">
+                        <img src="./static/sdu.svg" class="w-3/5" alt="Sydslesvigs danske Ungdomsforeninger" loading="lazy" width="300" height="120">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.dcbib.dk" class="flex items-center justify-center h-14 md:h-32" title="Dänische Bibliothek" target="_blank">
-                        <img src="./static/dcbib.svg" class="w-4/5" alt="Dänische Bibliothek" loading="lazy" width="300" height="96">
+                        <img src="./static/dcbib.svg" class="w-3/5" alt="Dänische Bibliothek" loading="lazy" width="300" height="96">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.comline-shop.de" class="flex items-center justify-center h-14 md:h-32" title="ComLine GmbH" target="_blank">
-                        <img src="./static/comline.svg" class="w-4/5" alt="ComLine GmbH" loading="lazy" width="300" height="101">
+                        <img src="./static/comline.svg" class="w-3/5" alt="ComLine GmbH" loading="lazy" width="300" height="101">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.flensburg.de" class="flex items-center justify-center h-14 md:h-32" title="Stadt Flensburg" target="_blank">
-                        <img src="./static/stadt-flensburg.svg" class="w-4/5" alt="Stadt Flensburg" loading="lazy" width="300" height="83">
+                        <img src="./static/stadt-flensburg.svg" class="w-3/5" alt="Stadt Flensburg" loading="lazy" width="300" height="83">
                     </a>
                 </div>
                 <div class="col-span-12 lg:col-span-6">
                     <a href="https://smarte-grenzregion.de" class="flex items-center justify-center h-14 md:h-32" title="Smarte Grenzregion zwischen den Meeren" target="_blank">
-                        <img src="./static/smarte-grenzregion.svg" class="w-4/5" alt="Smarte Grenzregion zwischen den Meeren" loading="lazy" width="300" height="55">
+                        <img src="./static/smarte-grenzregion.svg" class="w-3/5" alt="Smarte Grenzregion zwischen den Meeren" loading="lazy" width="300" height="55">
                     </a>
                 </div>
                 <div class="col-span-12 lg:col-span-6">
                     <a href="https://www.schleswig-holstein.de/DE/landesregierung/ministerien-behoerden/I/Staatskanzlei/staatskanzlei_node.html" class="flex items-center justify-center h-14 md:h-32" title="Staatskanzlei Schleswig-Holstein" target="_blank">
-                        <img src="./static/echtdigital_staatskanzlei.svg" class="w-4/5" alt="Staatskanzlei Schleswig-Holstein" loading="lazy" width="300" height="62">
+                        <img src="./static/echtdigital_staatskanzlei.svg" class="w-3/5" alt="Staatskanzlei Schleswig-Holstein" loading="lazy" width="300" height="62">
                     </a>
                 </div>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -87,6 +87,10 @@
         </div>
     </div>
 
+    <div class="absolute top-3 left-3 lg:top-5 lg:left-5">
+        <img class="h-12 lg:h-28" src="./static/oklabflensburg-logo.svg" alt="OK Lab Flensburg">
+    </div>
+
     <div id="about" class="bg-white">
         <div class="container mx-auto">
             <div class="grid grid-cols-12 gap-4">
@@ -312,7 +316,7 @@
     <div class="bg-white">
         <div class="container mx-auto px-3 xl:px-0">
             <h3 class="text-2xl lg:text-5xl font-bold pt-3 mb-4 lg:py-8">Partner</h3>
-            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Mit freundlicher Unterstützung von unseren Partnern und Förderern</p>
+            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Ein Event vom OK Lab Flensburg. Mit freundlicher Unterstützung von unseren Partnern und Förderern</p>
         </div>
 
         <div class="container mx-auto">
@@ -363,14 +367,6 @@
                     </a>
                 </div>
             </div>
-        </div>
-
-        <div class="container mx-auto px-3 xl:px-0">
-            <p class="text-lg lg:text-2xl leading-7 pb-5 lg:pb-8">Ein Event vom OK Lab Flensburg
-                <a href="https://oklabflensburg.de/">
-                    <img class="inline" src="./static/oklabflensburg-logo.svg" alt="OK Lab Flensburg" loading="lazy" width="130" height="150">
-                </a>
-            </p>
         </div>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,12 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" type="image/x-icon" href="./static/favicon.ico">
     <title>Open Data Day Flensburg - 2. März 2024</title>
+    <link rel="stylesheet" href="./main.css">
+    <link rel="preload" href="./static/fonts/grotesk/HKGrotesk-Bold.woff2" as="font" type="font/woff2" crossorigin>
+    
     <meta name="description" content="Open Data Day 2024 in Flensburg - Treffen Sie Experten, tauschen Sie Ideen aus und helfen Sie mit, die Digitalisierung demokratisch zu gestalten.">
+    <link rel="shortcut icon" type="image/x-icon" href="./static/favicon.ico">
 
     <meta property="og:url" content="https://oddfl.de">
     <meta property="og:type" content="website">
@@ -53,15 +56,13 @@
         }
     }
     </script>
-
-    <link rel="stylesheet" href="./main.css">
 </head>
 <body class="bg-gray-200 font-grotesk-regular">
     <div class="font-grotesk-bold h-screen flex items-center justify-center bg-cover bg-no-repeat bg-center bg-odd-hero relative">
         <div class="text-center">
             <span class="flex justify-center">
                 <a href="#" class="bg-odddarkgray inline-block">
-                    <img class="h-20 p-3" src="./static/odd-logo.svg" alt="Open Data Day 2024">
+                    <img class="p-3" src="./static/odd-logo.svg" alt="Open Data Day 2024" width="200" height="82">
                 </a>
             </span>
             <h1 class="inline-block text-white">
@@ -86,19 +87,15 @@
         </div>
     </div>
 
-    <div class="absolute top-3 left-3 lg:top-5 lg:left-5">
-        <img class="h-12 lg:h-28" src="./static/oklabflensburg-logo.svg" alt="OK Lab Flensburg">
-    </div>
-
     <div id="about" class="bg-white">
         <div class="container mx-auto">
             <div class="grid grid-cols-12 gap-4">
                 <div class="col-span-12 xl:col-span-8 pt-3 lg:py-24 px-3 xl:px-0">
                     <h3 class="text-2xl lg:text-5xl font-bold mb-4 lg:mb-8">Worum geht es?</h3>
-                    <p class="leading-7 lg:text-2xl text-lg">Der <a href="https://opendataday.org/de/" class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta" title="Open Data Day" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link">  Open Data Day</a> ist ein globales Event, der das Potenzial von offenen Daten und das Verständnis für den Umgang mit ihnen fördern soll. An diesem Tag werden weltweit verschiedene Veranstaltungen von lokalen Initiativen organisiert, um Menschen dazu zu ermutigen, sich mit offenen Daten auseinanderzusetzen und sie zu nutzen, um informierte Entscheidungen zu treffen und aktiv an gesellschaftlichen Prozessen teilzunehmen. Offene Daten werden längst von vielen Unternehmen und staatlichen Akteuren genutzt, um ihre eigenen Prozesse digital unterstützt zu optimieren. Am Open Data Day soll es aber darum gehen, wie die Zivilgesellschaft offene Daten für gemeinwohlorientierte Zwecke nutzen kann, und welche Chancen, Möglichkeiten und auch Hindernisse damit verbunden sind.</p>
+                    <p class="leading-7 lg:text-2xl text-lg">Der <a href="https://opendataday.org/de/" class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta" title="Open Data Day" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16">  Open Data Day</a> ist ein globales Event, der das Potenzial von offenen Daten und das Verständnis für den Umgang mit ihnen fördern soll. An diesem Tag werden weltweit verschiedene Veranstaltungen von lokalen Initiativen organisiert, um Menschen dazu zu ermutigen, sich mit offenen Daten auseinanderzusetzen und sie zu nutzen, um informierte Entscheidungen zu treffen und aktiv an gesellschaftlichen Prozessen teilzunehmen. Offene Daten werden längst von vielen Unternehmen und staatlichen Akteuren genutzt, um ihre eigenen Prozesse digital unterstützt zu optimieren. Am Open Data Day soll es aber darum gehen, wie die Zivilgesellschaft offene Daten für gemeinwohlorientierte Zwecke nutzen kann, und welche Chancen, Möglichkeiten und auch Hindernisse damit verbunden sind.</p>
                 </div>
                 <div class="col-span-12 xl:col-span-4 flex items-center justify-center pb-4 lg:pb-0">
-                    <img class="h-44 lg:h-64" src="./static/together.png" alt="Open Data Day Flensburg">
+                    <img src="./static/together.png" alt="Open Data Day Flensburg" loading="lazy" width="241" height="209">
                 </div>
             </div>
         </div>
@@ -223,14 +220,14 @@
                         24939 Flensburg
                     </address>
                     <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-12">In der Norderstraße, bekannt durch an Leinen hängende Schuhe, vielen Cafés und Kultureinrichtungen befindet sich die Dänische Bibliothek. Hier können wir den Open Data Day 2024 im Blauen Saal abhalten, der mit einem Panoramablick auf die Norderstraße und den Oluf Samson Gang eine herrliche Atmosphäre bietet.</p>
-                    <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-3" href="https://dcbib.dk" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> Dänische Bibliothek</a>
+                    <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-3" href="https://dcbib.dk" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> Dänische Bibliothek</a>
                     <ul>
                         <li>Parkhinweis: Folgt in Kürze.</li>
                         <li>Anfahrtsbeschreibung: Folgt in Kürze.</li>
                     </ul>
                 </div>
                 <div class="col-span-12 md:col-span-6 flex items-center justify-center">
-                    <img class="w-full" src="./static/dcbib.webp" alt="Dänische Bibliothek in Flensburg">
+                    <img class="w-full" src="./static/dcbib.webp" alt="Dänische Bibliothek in Flensburg" loading="lazy" width="960" height="640">
                 </div>
             </div>
         </div>
@@ -243,17 +240,17 @@
 
         <div class="container mx-auto md:container md:mx-auto grid grid-cols-12 px-3 xl:px-0">
             <div id="jesper" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/jesper-zedlitz.webp" alt="Jesper Zedlitz, Staatskanzlei Kiel">
+                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/jesper-zedlitz.webp" alt="Jesper Zedlitz, Staatskanzlei Kiel" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Open Data Schleswig-Holstein Aktueller Stand und Ausblick</h3>
                 <h4 class="text-lg lg:text-xl font-normal mb-1 lg:mb-2">Jesper Zedlitz, Staatskanzlei Kiel</h4>
                 <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-8">Seit Juni 2019 verfügt Schleswig-Holstein über ein Open-Data-Portal. Ab Start war es das im Hinblick auf die Anzahl der Datensätze größte Portal eines deutschen Bundeslandes. Diese Stellung konnte in der Zwischenzeit gefestigt und ausgebaut werden. Die Quantität geht jedoch nicht zu Lasten der Qualität. Von Anfang an wurden hohe Qualitätsansprüche bei den Metadaten an die Datenherausgeber gestellt. Mittlerweile hat sich einiges getan: Das schleswig-holsteinische Offene-Daten-Gesetz verpflichtet Landesbehörden, offene Daten bereitzustellen. Das Datennutzungsgesetz des Bundes gilt für viele weitere öffentliche Stellen. Es wurde eine Open-Data-Roadmap entwickelt, die beschreibt, was in den nächsten Jahren gemacht werden sollen. Ein zentraler Punkt in der Roadmap ist die Infrastruktur - daran hat gerade die Arbeit begonnen. Wir wollen und anschauen, was schon alles gemacht wurde und einen Blick auf kommende Dinge werfen, die man zum Teil auch noch mit gestalten kann.</p>
-                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://www.schleswig-holstein.de/DE/landesregierung/ministerien-behoerden/I/Staatskanzlei/staatskanzlei_node.html" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> Staatskanzlei Kiel</a>
+                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://www.schleswig-holstein.de/DE/landesregierung/ministerien-behoerden/I/Staatskanzlei/staatskanzlei_node.html" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> Staatskanzlei Kiel</a>
             </div>
 
             <div id="philip" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/philip-steffan.webp" alt="Philip Steffan, Jugend hackt">
+                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/philip-steffan.webp" alt="Philip Steffan, Jugend hackt" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Das Programm Jugend hackt - Mit Code die Welt verbessern</h3>
@@ -261,38 +258,38 @@
                 <p class="text-lg lg:text-2xl leading-7 mb-3">Jugend hackt ist ein Programm für junge Menschen, die mit ihren technischen Fähigkeiten die Welt verbessern wollen. Unterstützt von ehrenamtlichen Mentor:innen entwickeln unsere Teilnehmer:innen digitale Werkzeuge, Prototypen und Konzepte für eine bessere Zukunft. Das Angebot des Jugend hackt-Netzwerks umfasst Hackathon-Events in vielen Städten, regionale Labs, eine Online-Community und internationale Austauschprogramme.</p>
                 <p class="text-lg lg:text-2xl leading-7 mb-3">Ganz nach unserem Motto "Mit Code die Welt verbessern" geht es bei Jugend hackt um mehr als nur Programmieren lernen: Wir begreifen Technik als ein Mittel zu gesellschaftlicher Veränderung. Wir bestärken Jugendliche im verantwortungsbewussten Umgang mit Technik, um damit Lösungen für gesellschaftspolitische Fragen zu finden. Die Teilnahme an unseren Angeboten ist für die Jugendlichen soweit wie möglich kostenlos. Wir legen Wert auf Vielfalt in unserem Programm und fördern aktiv die Teilnahme von Jugendlichen, die sonst geringe Bildungschancen im Technik-Bereich vorfinden.</p>
                 <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-8">In Jugend hackt steckt jede Menge Ehrenamt: Hunderte freiwillige Mentor:innen im gesamten deutschsprachigen Raum engagieren sich für Jugend hackt. Wir sind stolz und dankbar für unsere engagierte Community, die wächst und uns vorantreibt. Unser Netzwerk in den Bereichen Bildung, Technologie, Engagement und Zivilgesellschaft wächst seit dem Programmstart 2013, im deutschsprachigen Raum und darüber hinaus.</p>
-                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://jugendhackt.org" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> Jugend hackt</a>
+                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://jugendhackt.org" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> Jugend hackt</a>
             </div>
 
             <div id="stk" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/stefan-kaufmann.webp" alt="Stefan Kaufmann, Wikimedia Deutschland">
+                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/stefan-kaufmann.webp" alt="Stefan Kaufmann, Wikimedia Deutschland" loading="lazy" width="600" height="600">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-8 lg:mb-16 xl:mb-20">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Open Data als Indikator für gelungene Verwaltungsdigitalisierung</h3>
                 <h4 class="text-lg lg:text-xl font-normal mb-1 lg:mb-2">Stefan Kaufmann, Wikimedia Deutschland</h4>
                 <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-8">Seit über zehn Jahren bemühen sich Bund, Länder und Kommunen um die Veröffentlichung offener Daten. Das sei gut fuer Demokratie und Transparenz, sagen die einen, das fördere die Wirtschaft, sagen die anderen. Viel zu lange ist aber eine wichtige Komponente komplett unter den Tisch gefallen: Wenn wir den Staat weitsichtig und sinnvoll digitalisieren, fallen offene Daten ganz nebenbei und gratis als Beifang heraus.</p>
-                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://www.wikimedia.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> Wikimedia Deutschland</a>
+                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://www.wikimedia.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> Wikimedia Deutschland</a>
             </div>
 
 
             <div id="malte" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/malte-zinke.webp" alt="Malte Zinke, Smarte Grenzregion">
+                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/malte-zinke.webp" alt="Malte Zinke, Smarte Grenzregion" loading="lazy" width="512" height="512">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-3 lg:mb-16">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Praktische Anwendungsfälle von Open Data in der Smarten Grenzregion</h3>
                 <h4 class="text-lg lg:text-xl font-normal mb-1 lg:mb-2">Malte Zinke, Smarte Grenzregion</h4>
                 <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-8">Die Smarte Grenzregion zwischen den Meeren ist ein vom Bund gefördertes Modellprojekt Smart City. Bis Ende 2026 setzen wir mehr als zwei Dutzend Maßnahmen um, bei denen der Open Data Grundsatz eine entscheidende Rolle spielt. Es werden mehrere Maßnahmen aus dem Projekt vorgestellt, mit denen wir selbst Open Data schaffen und vorhandene offene Daten aufbereiten.</p>
-                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://smarte-grenzregion.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> Smarte Grenzregion</a>
+                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://smarte-grenzregion.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> Smarte Grenzregion</a>
             </div>
 
             <div id="ulf" class="scroll-mt-5 col-span-12 md:col-span-4 lg:col-span-3 xl:col-span-2 flex items-start justify-center sm:justify-start mb-3 lg:mb-0">
-                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/ulf-andree-strohbach.webp" alt="Ulf Andree Strohbach, C20 Kiel">
+                <img class="h-44 lg:h-52 xl:h-48 rounded-full" src="./static/ulf-andree-strohbach.webp" alt="Ulf Andree Strohbach, C20 Kiel" loading="lazy" width="600" height="605">
             </div>
             <div class="col-span-12 md:col-span-8 lg:col-span-9 xl:col-span-10 mb-3 lg:mb-16">
                 <h3 class="font-grotesk-bold text-xl lg:text-3xl font-bold mb-3 lg:mb-6">Cyberangriffe mit ChatGPT und generativer KI</h3>
                 <h4 class="text-lg lg:text-xl font-normal mb-1 lg:mb-2">Ulf Andree Strohbach, C20 Kiel</h4>
                 <p class="text-lg lg:text-2xl leading-7 mb-3 lg:mb-8">Entdeckt die Welt der generativen KI im Zeichen von Open Source! In diesem Vortrag beleuchten wir die Möglichkeiten von Technologien wie ChatGPT und werfen gleichzeitig ein kritisches Licht auf die damit verbundenen Risiken. Erfahrt, wie Open Source-Ansätze die Entwicklung von KI demokratischer und transparenter machen können. Wir zeigen auf, wie einfach es ist, ChatGPT zu "jailbreaken", und wie Hacker KI für ihre Angriffe nutzen. Zugleich diskutieren wir, wie ihr euch mit KI gegen solche Bedrohungen schützen könnt. Ein besonderer Fokus liegt auf der Auswahl passender KI-Tools. Lernt, wie KI-Systeme auf euren eigenen Rechnern implementiert werden können und erlebt die beeindruckende Fähigkeit lernender KI. Dieser Vortrag bietet praxisnahe Beispiele und fundiertes Fachwissen, um euch ein umfassendes Verständnis der Künstlichen Intelligenz zu vermitteln. Erfahrt, wie ihr die Potenziale der KI verantwortungsbewusst nutzen und euch effektiv vor möglichen Risiken schützen könnt. Nehmt aktiv an diesem wichtigen Diskurs teil und nutzt die Gelegenheit, euer Wissen in diesem zukunftsweisenden Thema zu vertiefen!</p>
-                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://c-20.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link"> C20 - Institut für transformative Utopie</a>
+                <a class="text-lg lg:text-2xl text-oddlightblue hover:text-oddmagenta focus:text-oddmagenta mb-8 lg:mb-0" href="https://c-20.de" target="_blank"><img class="mb-1 h-4 w-4 inline" src="./static/external_link.svg" alt="Externer Link" loading="lazy" width="16" height="16"> C20 - Institut für transformative Utopie</a>
             </div>
 
         </div>
@@ -302,7 +299,7 @@
         <div class="container mx-auto">
             <div class="grid grid-cols-12 gap-3 lg:gap-12 px-3 xl:px-0">
                 <div class="col-span-12 xl:col-span-5 flex items-center justify-center pt-3 lg:pt-0">
-                    <img class="h-54" src="./static/oklabflensburg-community.webp" alt="OK Lab Flensburg Community Treffen">
+                    <img class="h-54" src="./static/oklabflensburg-community.webp" alt="OK Lab Flensburg Community Treffen" loading="lazy" width="960" height="640">
                 </div>
                 <div class="col-span-12 xl:col-span-7 pb-3 lg:py-24">
                     <h3 class="text-2xl lg:text-5xl font-bold mb-4 lg:mb-8">Komm vorbei auf 'nen Kaffee</h3>
@@ -315,57 +312,65 @@
     <div class="bg-white">
         <div class="container mx-auto px-3 xl:px-0">
             <h3 class="text-2xl lg:text-5xl font-bold pt-3 mb-4 lg:py-8">Partner</h3>
-            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Ein Event vom OK Lab Flensburg. Mit freundlicher Unterstützung von unseren Partnern und Förderern</p>
+            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Mit freundlicher Unterstützung von unseren Partnern und Förderern</p>
         </div>
 
         <div class="container mx-auto">
             <div class="grid grid-cols-12 gap-4 lg:gap-8 pb-4 lg:pb-8 px-3 xl:px-0">
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://hs-flensburg.de" class="flex items-center justify-center h-14 md:h-32" title="Hochschule Flensburg" target="_blank">
-                        <img src="./static/hochschule-flensburg.svg" class="w-3/5" alt="Hochschule Flensburg">
+                        <img src="./static/hochschule-flensburg.svg" class="w-4/5" alt="Hochschule Flensburg" loading="lazy" width="223" height="150">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://okfn.de" class="flex items-center justify-center h-14 md:h-32" title="Open Knowledge Foundation Deutschland" target="_blank">
-                        <img src="./static/okfde.svg" class="w-3/5" alt="Open Knowledge Foundation Deutschland">
+                        <img src="./static/okfde.svg" class="w-4/5" alt="Open Knowledge Foundation Deutschland" loading="lazy" width="300" height="136">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.wikimedia.de" class="flex items-center justify-center h-14 md:h-32" title="Wikimedia Deutschland" target="_blank">
-                        <img src="./static/wikimedia.svg" class="w-1/5" alt="Wikimedia Deutschland">
+                        <img src="./static/wikimedia.svg" class="w-1/5" alt="Wikimedia Deutschland" loading="lazy" width="149" height="150">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.sdu.de" class="flex items-center justify-center h-14 md:h-32" title="Sydslesvigs danske Ungdomsforeninger" target="_blank">
-                        <img src="./static/sdu.svg" class="w-3/5" alt="Sydslesvigs danske Ungdomsforeninger">
+                        <img src="./static/sdu.svg" class="w-4/5" alt="Sydslesvigs danske Ungdomsforeninger" loading="lazy" width="300" height="120">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.dcbib.dk" class="flex items-center justify-center h-14 md:h-32" title="Dänische Bibliothek" target="_blank">
-                        <img src="./static/dcbib.svg" class="w-3/5" alt="Dänische Bibliothek">
+                        <img src="./static/dcbib.svg" class="w-4/5" alt="Dänische Bibliothek" loading="lazy" width="300" height="96">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.comline-shop.de" class="flex items-center justify-center h-14 md:h-32" title="ComLine GmbH" target="_blank">
-                        <img src="./static/comline.svg" class="w-3/5" alt="ComLine GmbH">
+                        <img src="./static/comline.svg" class="w-4/5" alt="ComLine GmbH" loading="lazy" width="300" height="101">
                     </a>
                 </div>
                 <div class="col-span-6 lg:col-span-4 xl:col-span-3">
                     <a href="https://www.flensburg.de" class="flex items-center justify-center h-14 md:h-32" title="Stadt Flensburg" target="_blank">
-                        <img src="./static/stadt-flensburg.svg" class="w-3/5" alt="Stadt Flensburg">
+                        <img src="./static/stadt-flensburg.svg" class="w-4/5" alt="Stadt Flensburg" loading="lazy" width="300" height="83">
                     </a>
                 </div>
                 <div class="col-span-12 lg:col-span-6">
                     <a href="https://smarte-grenzregion.de" class="flex items-center justify-center h-14 md:h-32" title="Smarte Grenzregion zwischen den Meeren" target="_blank">
-                        <img src="./static/smarte-grenzregion.svg" class="w-3/5" alt="Smarte Grenzregion zwischen den Meeren">
+                        <img src="./static/smarte-grenzregion.svg" class="w-4/5" alt="Smarte Grenzregion zwischen den Meeren" loading="lazy" width="300" height="55">
                     </a>
                 </div>
                 <div class="col-span-12 lg:col-span-6">
                     <a href="https://www.schleswig-holstein.de/DE/landesregierung/ministerien-behoerden/I/Staatskanzlei/staatskanzlei_node.html" class="flex items-center justify-center h-14 md:h-32" title="Staatskanzlei Schleswig-Holstein" target="_blank">
-                        <img src="./static/echtdigital_staatskanzlei.svg" class="w-3/5" alt="Staatskanzlei Schleswig-Holstein">
+                        <img src="./static/echtdigital_staatskanzlei.svg" class="w-4/5" alt="Staatskanzlei Schleswig-Holstein" loading="lazy" width="300" height="62">
                     </a>
                 </div>
             </div>
+        </div>
+
+        <div class="container mx-auto px-3 xl:px-0">
+            <p class="text-lg lg:text-2xl leading-7 mb-5 lg:mb-8">Ein Event vom OK Lab Flensburg
+                <a href="https://oklabflensburg.de/">
+                    <img class="inline" src="./static/oklabflensburg-logo.svg" alt="OK Lab Flensburg" loading="lazy" width="130" height="150">
+                </a>
+            </p>
         </div>
     </div>
 


### PR DESCRIPTION
Hi,

been a pleasure to work on this :)

* reorder `<head>`, check https://github.com/rviscomi/capo.js for reference
* preload hero font
* slightly larger `odd-logo.svg`
* `loading="lazy"` for all below the fold images
* width+height for all images to reduce Layout Shift, check https://web.dev/articles/optimize-cls
* ~~slightly larger Partner images~~
* ~~moved own logo to bottom ("the donkey calls itself at the end")~~

Further possible optimizations regarding page payload:

* reduce .svg size with https://jakearchibald.github.io/svgomg/ (our own logo would save 50%)
* hero background to .svg (perhaps original file was a .svg anyway?)

Cya on monday,
midzer